### PR TITLE
fix(copy): update tagline to "worry free speech to text"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "murmur"
 version = "0.1.0"
 edition = "2021"
-description = "Cross-platform, local voice dictation. Hold a key, speak, release — your words appear at the cursor. Powered by whisper.cpp, runs 100% on-device."
+description = "Cross-platform, local voice dictation. Hold a key, speak, release — worry free speech to text. Powered by whisper.cpp, runs 100% on-device."
 license = "MIT"
 repository = "https://github.com/jacobfreck/murmur"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # murmur
 
-Cross-platform, local voice dictation. Hold a key, speak, release — your words appear at the cursor.
+Cross-platform, local voice dictation. Hold a key, speak, release — worry free speech to text.
 
 [![CI](https://github.com/jafreck/murmur/actions/workflows/ci.yml/badge.svg)](https://github.com/jafreck/murmur/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use clap::{Parser, Subcommand};
 #[derive(Parser)]
 #[command(
     name = "murmur",
-    about = "Cross-platform, local voice dictation. Hold a key, speak, release — your words appear at the cursor.",
+    about = "Cross-platform, local voice dictation. Hold a key, speak, release — worry free speech to text.",
     version
 )]
 struct Cli {


### PR DESCRIPTION
Updates the tagline from "your words appear at the cursor" to "worry free speech to text" across README.md, Cargo.toml, and src/main.rs CLI help.