### PR TITLE
feat: add Homebrew tap support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -149,3 +149,73 @@ jobs:
         run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  update-homebrew:
+    name: Update Homebrew tap
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Configure deploy key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}" > ~/.ssh/tap_key
+          chmod 600 ~/.ssh/tap_key
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+      - name: Clone tap repository
+        run: git clone git@github.com:jafreck/homebrew-murmur.git tap
+        env:
+          GIT_SSH_COMMAND: "ssh -i ~/.ssh/tap_key"
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Download release tarballs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download "${{ github.event.release.tag_name }}" \
+            --repo jafreck/murmur \
+            --pattern "murmur-darwin-arm64.tar.gz" \
+            --pattern "murmur-darwin-x86_64.tar.gz" \
+            --pattern "murmur-linux-x86_64.tar.gz"
+
+      - name: Update formula version and checksums
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          SHA_ARM64=$(sha256sum murmur-darwin-arm64.tar.gz | cut -d ' ' -f1)
+          SHA_X86_64=$(sha256sum murmur-darwin-x86_64.tar.gz | cut -d ' ' -f1)
+          SHA_LINUX=$(sha256sum murmur-linux-x86_64.tar.gz | cut -d ' ' -f1)
+
+          python3 <<PYEOF
+          with open("tap/Formula/murmur.rb") as f:
+              lines = f.readlines()
+
+          shas = ["${SHA_ARM64}", "${SHA_X86_64}", "${SHA_LINUX}"]
+          sha_idx = 0
+          for i, line in enumerate(lines):
+              if 'version "' in line:
+                  indent = line[:len(line) - len(line.lstrip())]
+                  lines[i] = f'{indent}version "${VERSION}"\n'
+              elif 'sha256 "' in line and sha_idx < len(shas):
+                  indent = line[:len(line) - len(line.lstrip())]
+                  lines[i] = f'{indent}sha256 "{shas[sha_idx]}"\n'
+                  sha_idx += 1
+
+          with open("tap/Formula/murmur.rb", "w") as f:
+              f.writelines(lines)
+          PYEOF
+
+      - name: Commit and push formula update
+        working-directory: tap
+        env:
+          GIT_SSH_COMMAND: "ssh -i ~/.ssh/tap_key"
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/murmur.rb
+          git diff --cached --quiet && echo "No changes to commit" && exit 0
+          git commit -m "murmur ${{ github.event.release.tag_name }}"
+          git push origin main
+

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ MURMUR_VERSION=v0.1.0 bash <(curl -sSfL https://github.com/jafreck/murmur/releas
 .\scripts\install.ps1 -Version v0.1.0
 ```
 
+### Homebrew (macOS / Linux)
+
+```bash
+brew install jafreck/murmur/murmur
+```
+
 ### From source
 
 ```bash


### PR DESCRIPTION
## Summary

Adds automated Homebrew tap support via a separate [homebrew-murmur](https://github.com/jafreck/homebrew-murmur) repository.

### What's included

- **CI automation** in `publish.yml`: new `update-homebrew` job that runs on each release, downloads the built tarballs, computes SHA256 checksums, and pushes an updated formula to the tap repo
- **README** updated with `brew install jafreck/murmur/murmur` instructions

### How it works

1. A GitHub Release is published
2. The `update-homebrew` job downloads the macOS (arm64, x86_64) and Linux (x86_64) tarballs
3. Computes SHA256 checksums and updates the formula version + hashes
4. Pushes the updated `Formula/murmur.rb` to `jafreck/homebrew-murmur` via deploy key

### Setup

A deploy key (`HOMEBREW_TAP_DEPLOY_KEY`) has already been configured to grant the workflow write access to the tap repo.