### PR TITLE
fix: join streaming thread before final transcription to prevent race

### DIFF
--- a/src/app/effects.rs
+++ b/src/app/effects.rs
@@ -21,7 +21,7 @@ pub struct EffectContext<'a> {
     pub config: &'a mut Config,
     pub state: &'a mut AppState,
     pub tx: &'a mpsc::Sender<AppMessage>,
-    pub streaming_stop: &'a mut Option<mpsc::Sender<()>>,
+    pub streaming_stop: &'a mut Option<streaming::StreamingHandle>,
     pub hotkey_config: &'a SharedHotkeyConfig,
     pub capture_flag: &'a CaptureFlag,
 }
@@ -54,9 +54,9 @@ pub fn apply_effect(
             start_streaming(ctx);
         }
         AppEffect::StopStreaming => {
-            if let Some(stop) = ctx.streaming_stop.take() {
+            if let Some(handle) = ctx.streaming_stop.take() {
                 info!("Stopping streaming transcription");
-                let _ = stop.send(());
+                handle.stop_and_join();
             }
         }
         AppEffect::InsertText(text) => {
@@ -153,9 +153,12 @@ pub fn apply_effect(
 }
 
 fn stop_and_transcribe(ctx: &mut EffectContext<'_>) {
-    // Stop streaming first (if running)
-    if let Some(stop) = ctx.streaming_stop.take() {
-        let _ = stop.send(());
+    // Stop streaming first (if running) and wait for the thread to exit.
+    // This prevents concurrent access to the shared WhisperContext between
+    // the streaming thread and the final transcription thread below.
+    if let Some(handle) = ctx.streaming_stop.take() {
+        info!("Waiting for streaming thread to finish before final transcription");
+        handle.stop_and_join();
     }
 
     let Some(transcriber) = ctx.transcriber.as_ref().map(Arc::clone) else {
@@ -255,14 +258,14 @@ fn start_streaming(ctx: &mut EffectContext<'_>) {
         }
     });
 
-    let stop = streaming::start_streaming(
+    let handle = streaming::start_streaming(
         sample_buffer,
         transcriber,
         translate,
         spoken_punct,
         streaming_tx,
     );
-    *ctx.streaming_stop = Some(stop);
+    *ctx.streaming_stop = Some(handle);
 }
 
 fn open_config_file() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -201,7 +201,7 @@ pub fn run() -> Result<()> {
         error!("Failed to warm microphone: {e}");
     }
     let mut state = AppState::new(&config);
-    let mut streaming_stop: Option<mpsc::Sender<()>> = None;
+    let mut streaming_stop: Option<crate::transcription::streaming::StreamingHandle> = None;
 
     println!("murmur v{VERSION}");
     println!("Hotkey: {}", config.hotkey);

--- a/src/transcription/streaming.rs
+++ b/src/transcription/streaming.rs
@@ -35,22 +35,48 @@ pub enum StreamingEvent {
     PartialText { text: String, replace_chars: usize },
 }
 
+/// Handle returned by [`start_streaming`] to control the streaming thread.
+///
+/// Dropping the handle sends a stop signal (by disconnecting the channel),
+/// but does **not** block until the thread exits. Call [`stop_and_join`]
+/// when you need to guarantee the thread has exited before reusing the
+/// `Transcriber` (e.g. before starting a final transcription pass).
+pub struct StreamingHandle {
+    stop_tx: mpsc::Sender<()>,
+    join_handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl StreamingHandle {
+    /// Signal the streaming thread to stop and block until it exits.
+    ///
+    /// This prevents concurrent access to the shared `WhisperContext`
+    /// between the streaming thread and a subsequent transcription thread.
+    pub fn stop_and_join(mut self) {
+        let _ = self.stop_tx.send(());
+        if let Some(handle) = self.join_handle.take() {
+            if let Err(e) = handle.join() {
+                log::error!("Streaming thread panicked: {e:?}");
+            }
+        }
+    }
+}
+
 /// Start streaming transcription in a background thread.
 ///
 /// Reads from `sample_buffer` (the AudioRecorder's shared buffer), transcribes
 /// overlapping chunks, and sends incremental text via `tx`.
 ///
-/// Returns a handle that, when dropped or sent `()`, signals the thread to stop.
+/// Returns a [`StreamingHandle`] that can stop and join the thread.
 pub fn start_streaming(
     sample_buffer: Arc<Mutex<Vec<f32>>>,
     transcriber: Arc<Transcriber>,
     translate: bool,
     spoken_punctuation: bool,
     tx: mpsc::Sender<StreamingEvent>,
-) -> mpsc::Sender<()> {
+) -> StreamingHandle {
     let (stop_tx, stop_rx) = mpsc::channel::<()>();
 
-    std::thread::spawn(move || {
+    let join_handle = std::thread::spawn(move || {
         streaming_loop(
             sample_buffer,
             transcriber,
@@ -61,7 +87,10 @@ pub fn start_streaming(
         );
     });
 
-    stop_tx
+    StreamingHandle {
+        stop_tx,
+        join_handle: Some(join_handle),
+    }
 }
 
 // ── Internal ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

When streaming mode is active, `stop_and_transcribe()` sent a stop signal to the streaming thread but **did not wait for it to exit** before spawning the final transcription thread. Both threads held `Arc<Transcriber>` clones and could concurrently call `whisper_full_with_state` on the same `WhisperContext`, causing undefined behavior in the whisper.cpp C library (`WHISPER_ASSERT` → `abort()`).

Observed as a `SIGABRT` immediately after a successful transcription:
```
ggml_metal_free: deallocating
[INFO  murmur::app::effects] Transcription: And feel free to suggest any other optimizations you would recommend.
[1]    63547 abort      target/debug/murmur start
```

## Fix

Introduce `StreamingHandle` that wraps both the stop channel sender and the thread's `JoinHandle`. The new `stop_and_join()` method sends the stop signal **and blocks until the streaming thread exits**, ensuring exclusive access to the `WhisperContext` before the final transcription begins.

### Changes
- **`streaming.rs`**: Add `StreamingHandle` struct with `stop_and_join()`; `start_streaming()` now returns it instead of a bare `mpsc::Sender<()>`.
- **`effects.rs`**: Update `StopStreaming` and `stop_and_transcribe()` to use `handle.stop_and_join()` instead of fire-and-forget `send(())`.
- **`mod.rs`**: Update `streaming_stop` type to `Option<StreamingHandle>`.