### PR TITLE
fix: remove n_threads override that caused CPU spikes

### DIFF
--- a/src/transcription/transcriber.rs
+++ b/src/transcription/transcriber.rs
@@ -330,10 +330,6 @@ impl Transcriber {
         }
 
         let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
-        let n_threads = std::thread::available_parallelism()
-            .map(|n| n.get() as i32)
-            .unwrap_or(4);
-        params.set_n_threads(n_threads);
         params.set_language(self.language_param());
         params.set_translate(translate);
         params.set_print_special(false);
@@ -387,10 +383,6 @@ impl Transcriber {
         }
 
         let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
-        let n_threads = std::thread::available_parallelism()
-            .map(|n| n.get() as i32)
-            .unwrap_or(4);
-        params.set_n_threads(n_threads);
         params.set_language(self.language_param());
         params.set_translate(translate);
         params.set_print_special(false);


### PR DESCRIPTION
## Problem

PR #43 introduced an explicit `set_n_threads(available_parallelism())` in both `streaming_transcribe` and `run_inference_with_context`. This pegged **all** CPU cores (e.g. 12 on Apple Silicon) during every transcription, causing severe CPU spikes and system sluggishness.

## Fix

Remove the override from both methods and let whisper.cpp use its built-in default of `min(4, cpu_count)`, which is well-tuned for balancing speed and system responsiveness.