### PR TITLE
perf: fix transcription latency regression

### DIFF
--- a/src/transcription/streaming.rs
+++ b/src/transcription/streaming.rs
@@ -8,6 +8,7 @@
 //! Once the window exceeds `MAX_WINDOW_SECS` the start anchor slides
 //! forward to keep each Whisper pass short and responsive.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 
@@ -42,15 +43,18 @@ pub enum StreamingEvent {
 /// `Transcriber` (e.g. before starting a final transcription pass).
 pub struct StreamingHandle {
     stop_tx: mpsc::Sender<()>,
+    abort_flag: Arc<AtomicBool>,
     join_handle: Option<std::thread::JoinHandle<()>>,
 }
 
 impl StreamingHandle {
     /// Signal the streaming thread to stop and block until it exits.
     ///
-    /// This prevents concurrent access to the shared `WhisperContext`
-    /// between the streaming thread and a subsequent transcription thread.
+    /// Sets the abort flag first so any in-progress whisper inference
+    /// is cancelled immediately, then sends the channel stop signal
+    /// and joins the thread.
     pub fn stop_and_join(mut self) {
+        self.abort_flag.store(true, Ordering::Relaxed);
         let _ = self.stop_tx.send(());
         if let Some(handle) = self.join_handle.take() {
             if let Err(e) = handle.join() {
@@ -74,6 +78,8 @@ pub fn start_streaming(
     tx: mpsc::Sender<StreamingEvent>,
 ) -> StreamingHandle {
     let (stop_tx, stop_rx) = mpsc::channel::<()>();
+    let abort_flag = Arc::new(AtomicBool::new(false));
+    let abort_flag_clone = Arc::clone(&abort_flag);
 
     let join_handle = std::thread::spawn(move || {
         streaming_loop(
@@ -83,11 +89,13 @@ pub fn start_streaming(
             filler_word_removal,
             tx,
             stop_rx,
+            abort_flag_clone,
         );
     });
 
     StreamingHandle {
         stop_tx,
+        abort_flag,
         join_handle: Some(join_handle),
     }
 }
@@ -101,6 +109,7 @@ fn streaming_loop(
     filler_word_removal: bool,
     tx: mpsc::Sender<StreamingEvent>,
     stop_rx: mpsc::Receiver<()>,
+    abort_flag: Arc<AtomicBool>,
 ) {
     let min_new_samples = (MIN_NEW_AUDIO_SECS * TARGET_RATE as f32) as usize;
     let max_window_samples = (MAX_WINDOW_SECS * TARGET_RATE as f32) as usize;
@@ -156,15 +165,19 @@ fn streaming_loop(
             continue;
         }
 
-        let mut full_text =
-            match transcriber.streaming_transcribe(&mut whisper_state, &window, translate) {
-                Ok(t) => t,
-                Err(e) => {
-                    log::error!("Streaming transcription failed: {e}");
-                    last_transcribed = total_samples;
-                    continue;
-                }
-            };
+        let mut full_text = match transcriber.streaming_transcribe(
+            &mut whisper_state,
+            &window,
+            translate,
+            &abort_flag,
+        ) {
+            Ok(t) => t,
+            Err(e) => {
+                log::error!("Streaming transcription failed: {e}");
+                last_transcribed = total_samples;
+                continue;
+            }
+        };
 
         // Re-read the current buffer position so the min-new-audio threshold
         // is relative to *now*, not to when this transcription started.

--- a/src/transcription/transcriber.rs
+++ b/src/transcription/transcriber.rs
@@ -1,11 +1,22 @@
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use whisper_rs::{
     FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters, WhisperState,
 };
 
 use crate::config::Config;
 use crate::transcription::vad;
+
+/// Compute thread count: use 75% of available cores, clamped to [4, 8].
+/// This balances throughput against CPU pressure (avoids pegging all cores).
+fn inference_thread_count() -> i32 {
+    let n = std::thread::available_parallelism()
+        .map(|n| n.get() as i32)
+        .unwrap_or(4);
+    (n * 3 / 4).clamp(4, 8)
+}
 
 /// Minimum audio duration in samples at 16 kHz.
 /// Clips shorter than this tend to produce hallucinated output.
@@ -319,17 +330,22 @@ impl Transcriber {
     /// - skips VAD and min-length checks (the streaming loop handles those),
     /// - enables `single_segment` mode (skips segment-boundary detection),
     /// - enables `no_context` (each pass re-transcribes the full window).
+    ///
+    /// If `abort_flag` is set to `true` mid-inference, whisper will abort
+    /// early and an empty string is returned.
     pub fn streaming_transcribe(
         &self,
         state: &mut WhisperState,
         samples: &[f32],
         translate: bool,
+        abort_flag: &Arc<AtomicBool>,
     ) -> Result<String> {
         if samples.is_empty() {
             return Ok(String::new());
         }
 
         let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
+        params.set_n_threads(inference_thread_count());
         params.set_language(self.language_param());
         params.set_translate(translate);
         params.set_print_special(false);
@@ -340,9 +356,16 @@ impl Transcriber {
         params.set_single_segment(true);
         params.set_no_context(true);
 
+        let flag = Arc::clone(abort_flag);
+        params.set_abort_callback_safe(move || flag.load(Ordering::Relaxed));
+
         state
             .full(params, samples)
             .map_err(|e| anyhow::anyhow!("Transcription failed: {e}"))?;
+
+        if abort_flag.load(Ordering::Relaxed) {
+            return Ok(String::new());
+        }
 
         let text = self.extract_text(state);
 
@@ -383,6 +406,7 @@ impl Transcriber {
         }
 
         let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
+        params.set_n_threads(inference_thread_count());
         params.set_language(self.language_param());
         params.set_translate(translate);
         params.set_print_special(false);

--- a/src/transcription/vad.rs
+++ b/src/transcription/vad.rs
@@ -76,6 +76,9 @@ fn detect_speech(samples: &[f32]) -> Result<bool, voice_activity_detector::Error
         return Ok(false);
     }
 
+    // Pre-compute the threshold so we can exit early once enough
+    // speech chunks are found, avoiding redundant ONNX inference.
+    let required_speech_chunks = (MIN_SPEECH_RATIO * total_chunks as f32).ceil() as usize;
     let mut speech_chunks: usize = 0;
 
     for chunk_start in (0..samples.len()).step_by(CHUNK_SIZE) {
@@ -85,6 +88,12 @@ fn detect_speech(samples: &[f32]) -> Result<bool, voice_activity_detector::Error
         let probability = vad.predict(chunk.iter().copied());
         if probability >= SPEECH_THRESHOLD {
             speech_chunks += 1;
+            if speech_chunks >= required_speech_chunks {
+                log::debug!(
+                    "VAD: early exit — {speech_chunks}/{total_chunks} chunks contain speech"
+                );
+                return Ok(true);
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

Transcription latency regressed from ~0.25s to 5+ seconds after commit e6f3da7 removed the `n_threads` override, dropping thread count from all available cores to whisper.cpp's default of `min(4, cpu_count)` = 4.

With streaming enabled, `stop_and_join()` also blocks until the current (now slower) inference pass finishes, adding several more seconds.

## Fix

### 1. Restore moderate `n_threads`
Use `(available_parallelism * 3/4).clamp(4, 8)` for both streaming and final transcription. This avoids the CPU-pegging issue from the original all-core override while providing meaningful parallelism:
- Apple Silicon M1 (8 cores): 6 threads
- Apple Silicon M2 Max (12 cores): 8 threads
- 4-core machine: 4 threads

### 2. Streaming abort callback
Wire an `Arc<AtomicBool>` abort flag into whisper's `set_abort_callback_safe`. When `stop_and_join()` is called, the flag is set **before** the channel signal, so any in-progress inference is cancelled immediately instead of blocking for the full pass duration.

### 3. VAD early exit
`detect_speech()` previously processed every 512-sample chunk through ONNX inference even after finding speech. Now exits as soon as `MIN_SPEECH_RATIO` (5%) of chunks are confirmed as speech, saving up to 95% of VAD time on clips with clear speech.

## Testing
- All 616 tests pass
- No clippy warnings