### PR TITLE
feat: integrate local LLM via Ollama for meeting suggestions and summaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3393,6 +3393,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/murmur-copilot/src-tauri/Cargo.toml
+++ b/crates/murmur-copilot/src-tauri/Cargo.toml
@@ -8,6 +8,7 @@ description = "Tauri-based meeting copilot with live streaming transcription ove
 [dependencies]
 murmur-core = { version = "0.1.1", path = "../../murmur-core" }
 tauri = { version = "2", features = ["tray-icon"] }
+tokio = { version = "1", features = ["rt"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 log = "0.4"

--- a/crates/murmur-copilot/src-tauri/src/commands.rs
+++ b/crates/murmur-copilot/src-tauri/src/commands.rs
@@ -1,8 +1,9 @@
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use log::info;
 use tauri::{AppHandle, Emitter, Manager, State};
 
+use crate::llm::LlmManager;
 use crate::meeting::{MeetingSession, SessionState, TranscriptEntry};
 use crate::overlay;
 
@@ -10,6 +11,7 @@ use crate::overlay;
 pub struct AppState {
     pub session: Mutex<Option<MeetingSession>>,
     pub stealth_enabled: Mutex<bool>,
+    pub llm: Arc<Mutex<LlmManager>>,
 }
 
 #[tauri::command]
@@ -103,4 +105,92 @@ pub fn toggle_stealth(state: State<'_, AppState>, app: AppHandle) -> Result<bool
 
     info!("stealth mode toggled to {new_state}");
     Ok(new_state)
+}
+
+/// Get an AI-generated suggestion based on the current meeting transcript.
+#[tauri::command]
+pub async fn get_suggestion(state: State<'_, AppState>) -> Result<Option<String>, String> {
+    let transcript_text = {
+        let session_guard = state.session.lock().map_err(|e| e.to_string())?;
+        match session_guard.as_ref() {
+            Some(session) => session.transcript_text(),
+            None => return Err("no active meeting".into()),
+        }
+    };
+
+    if transcript_text.is_empty() {
+        return Ok(None);
+    }
+
+    let llm = state.llm.clone();
+    tokio::task::spawn_blocking(move || {
+        let llm = llm.lock().map_err(|e| e.to_string())?;
+        Ok(llm.suggest(&transcript_text))
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+/// Generate a full meeting summary from the transcript.
+#[tauri::command]
+pub async fn generate_summary(state: State<'_, AppState>) -> Result<Option<String>, String> {
+    let transcript_text = {
+        let session_guard = state.session.lock().map_err(|e| e.to_string())?;
+        match session_guard.as_ref() {
+            Some(session) => session.transcript_text(),
+            None => return Err("no meeting session available".into()),
+        }
+    };
+
+    if transcript_text.is_empty() {
+        return Ok(None);
+    }
+
+    let llm = state.llm.clone();
+    tokio::task::spawn_blocking(move || {
+        let llm = llm.lock().map_err(|e| e.to_string())?;
+        Ok(llm.summarize(&transcript_text))
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+/// Check if the LLM backend is available and return model info.
+#[tauri::command]
+pub fn get_llm_status(state: State<'_, AppState>) -> Result<LlmStatus, String> {
+    let llm = state.llm.lock().map_err(|e| e.to_string())?;
+    Ok(LlmStatus {
+        available: llm.is_available(),
+        model: llm.model_name().map(String::from),
+    })
+}
+
+#[derive(serde::Serialize)]
+pub struct LlmStatus {
+    pub available: bool,
+    pub model: Option<String>,
+}
+
+/// Extract action items from the meeting transcript.
+#[tauri::command]
+pub async fn extract_action_items(state: State<'_, AppState>) -> Result<Option<String>, String> {
+    let transcript_text = {
+        let session_guard = state.session.lock().map_err(|e| e.to_string())?;
+        match session_guard.as_ref() {
+            Some(session) => session.transcript_text(),
+            None => return Err("no meeting session available".into()),
+        }
+    };
+
+    if transcript_text.is_empty() {
+        return Ok(None);
+    }
+
+    let llm = state.llm.clone();
+    tokio::task::spawn_blocking(move || {
+        let llm = llm.lock().map_err(|e| e.to_string())?;
+        Ok(llm.action_items(&transcript_text))
+    })
+    .await
+    .map_err(|e| e.to_string())?
 }

--- a/crates/murmur-copilot/src-tauri/src/llm.rs
+++ b/crates/murmur-copilot/src-tauri/src/llm.rs
@@ -1,0 +1,77 @@
+use log::{info, warn};
+use murmur_core::llm::{
+    ollama::OllamaProvider,
+    prompt::{action_items_prompt, suggestion_prompt, summary_prompt},
+    LlmProvider,
+};
+
+/// Manages the LLM lifecycle for the copilot.
+pub struct LlmManager {
+    provider: Option<Box<dyn LlmProvider>>,
+}
+
+impl LlmManager {
+    /// Try to connect to Ollama. If unavailable, the manager is created but
+    /// suggestions/summaries will return `None`.
+    pub fn try_connect(url: &str, model: &str) -> Self {
+        let provider = OllamaProvider::with_url(url, model);
+        if provider.is_available() {
+            info!("LLM connected — model '{model}' via Ollama");
+            Self {
+                provider: Some(Box::new(provider)),
+            }
+        } else {
+            warn!("Ollama not available — LLM features disabled");
+            Self { provider: None }
+        }
+    }
+
+    /// Whether an LLM provider is connected and ready.
+    pub fn is_available(&self) -> bool {
+        self.provider.is_some()
+    }
+
+    /// The name of the active model, if any.
+    pub fn model_name(&self) -> Option<&str> {
+        self.provider.as_ref().map(|p| p.model_name())
+    }
+
+    /// Generate contextual suggestions from recent transcript.
+    pub fn suggest(&self, transcript: &str) -> Option<String> {
+        let provider = self.provider.as_ref()?;
+        let messages = suggestion_prompt(transcript);
+        match provider.generate(&messages) {
+            Ok(response) => Some(response),
+            Err(e) => {
+                warn!("LLM suggestion failed: {e}");
+                None
+            }
+        }
+    }
+
+    /// Generate a post-meeting summary.
+    pub fn summarize(&self, transcript: &str) -> Option<String> {
+        let provider = self.provider.as_ref()?;
+        let messages = summary_prompt(transcript);
+        match provider.generate(&messages) {
+            Ok(response) => Some(response),
+            Err(e) => {
+                warn!("LLM summary failed: {e}");
+                None
+            }
+        }
+    }
+
+    /// Extract action items from a transcript.
+    pub fn action_items(&self, transcript: &str) -> Option<String> {
+        let provider = self.provider.as_ref()?;
+        let messages = action_items_prompt(transcript);
+        match provider.generate(&messages) {
+            Ok(response) => Some(response),
+            Err(e) => {
+                warn!("LLM action items extraction failed: {e}");
+                None
+            }
+        }
+    }
+}

--- a/crates/murmur-copilot/src-tauri/src/main.rs
+++ b/crates/murmur-copilot/src-tauri/src/main.rs
@@ -1,16 +1,26 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod commands;
+mod llm;
 mod meeting;
 mod overlay;
 
 use log::info;
+use murmur_core::config::Config;
 
 fn main() {
     env_logger::init();
     info!("starting murmur-copilot");
 
+    let config = Config::load();
+    let llm_manager = llm::LlmManager::try_connect(&config.ollama_url, &config.llm_model);
+
     tauri::Builder::default()
+        .manage(commands::AppState {
+            session: std::sync::Mutex::new(None),
+            stealth_enabled: std::sync::Mutex::new(config.stealth_mode),
+            llm: std::sync::Arc::new(std::sync::Mutex::new(llm_manager)),
+        })
         .setup(|app| {
             overlay::configure_overlay(app)?;
             info!("overlay window configured");
@@ -23,6 +33,10 @@ fn main() {
             commands::list_audio_devices,
             commands::set_system_audio_device,
             commands::toggle_stealth,
+            commands::get_suggestion,
+            commands::generate_summary,
+            commands::get_llm_status,
+            commands::extract_action_items,
         ])
         .run(tauri::generate_context!())
         .expect("error while running murmur-copilot");

--- a/crates/murmur-copilot/src-tauri/src/meeting.rs
+++ b/crates/murmur-copilot/src-tauri/src/meeting.rs
@@ -103,6 +103,22 @@ impl MeetingSession {
         self.state
     }
 
+    /// Returns the current transcript as a single formatted string.
+    pub fn transcript_text(&self) -> String {
+        let entries = self.transcript.lock().unwrap();
+        entries
+            .iter()
+            .map(|e| {
+                let label = match e.speaker {
+                    Speaker::User => "You",
+                    Speaker::Remote => "Remote",
+                };
+                format!("{label}: {}", e.text)
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
     /// Configure (or clear) the system audio device at runtime.
     pub fn set_system_audio_device(&mut self, device_name: Option<&str>) {
         // Stop any existing system capture.

--- a/crates/murmur-copilot/src-tauri/src/overlay.rs
+++ b/crates/murmur-copilot/src-tauri/src/overlay.rs
@@ -1,17 +1,8 @@
 use tauri::{App, Manager};
 
-use crate::commands::AppState;
-use std::sync::Mutex;
-
-/// Configure the overlay window and register managed state.
+/// Configure the overlay window.
 pub fn configure_overlay(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {
     let config = murmur_core::config::Config::load();
-
-    // Register application state so Tauri commands can access it.
-    app.manage(AppState {
-        session: Mutex::new(None),
-        stealth_enabled: Mutex::new(config.stealth_mode),
-    });
 
     // The overlay window is declared in tauri.conf.json with:
     //   transparent: true, decorations: false, alwaysOnTop: true

--- a/crates/murmur-copilot/src/App.ts
+++ b/crates/murmur-copilot/src/App.ts
@@ -21,6 +21,11 @@ interface AudioDevice {
   is_loopback_hint: boolean;
 }
 
+interface LlmStatus {
+  available: boolean;
+  model: string | null;
+}
+
 function invoke(cmd: string, args?: Record<string, unknown>): Promise<unknown> {
   return window.__TAURI__!.core.invoke(cmd, args);
 }
@@ -36,11 +41,35 @@ export function initApp(): void {
   const btnStart = document.getElementById("btn-start") as HTMLButtonElement;
   const btnStop = document.getElementById("btn-stop") as HTMLButtonElement;
   const btnStealth = document.getElementById("btn-stealth") as HTMLButtonElement;
+  const btnSuggest = document.getElementById("btn-suggest") as HTMLButtonElement;
   const statusEl = document.getElementById("status") as HTMLSpanElement;
+  const llmStatusEl = document.getElementById("llm-status") as HTMLSpanElement;
   const transcriptEl = document.getElementById("transcript") as HTMLElement;
   const deviceSelect = document.getElementById("device-select") as HTMLSelectElement;
+  const suggestionPanel = document.getElementById("suggestion-panel") as HTMLElement;
+  const suggestionContent = document.getElementById("suggestion-content") as HTMLElement;
+  const summaryPanel = document.getElementById("summary-panel") as HTMLElement;
+  const summaryContent = document.getElementById("summary-content") as HTMLElement;
 
   const display = new TranscriptDisplay(transcriptEl);
+
+  // ── LLM status check ──────────────────────────────────────────────
+  async function checkLlmStatus() {
+    try {
+      const status = (await invoke("get_llm_status")) as LlmStatus;
+      if (status.available) {
+        llmStatusEl.textContent = "🟢";
+        llmStatusEl.title = `LLM connected: ${status.model}`;
+      } else {
+        llmStatusEl.textContent = "🔴";
+        llmStatusEl.title = "LLM disconnected";
+      }
+    } catch {
+      llmStatusEl.textContent = "🔴";
+      llmStatusEl.title = "LLM disconnected";
+    }
+  }
+  checkLlmStatus();
 
   // ── Populate audio device selector ─────────────────────────────────
   async function loadDevices() {
@@ -72,6 +101,9 @@ export function initApp(): void {
       await invoke("start_meeting");
       btnStop.disabled = false;
       statusEl.textContent = "recording";
+      suggestionPanel.classList.remove("hidden");
+      summaryPanel.classList.add("hidden");
+      suggestionContent.textContent = "No suggestions yet.";
     } catch (err) {
       statusEl.textContent = `error: ${err}`;
       btnStart.disabled = false;
@@ -88,9 +120,35 @@ export function initApp(): void {
       if (entries && entries.length > 0) {
         display.setFinalTranscript(entries);
       }
+      suggestionPanel.classList.add("hidden");
+
+      // Auto-generate summary when meeting ends
+      try {
+        const summary = (await invoke("generate_summary")) as string | null;
+        if (summary) {
+          summaryContent.textContent = summary;
+          summaryPanel.classList.remove("hidden");
+        }
+      } catch {
+        // LLM may not be available — that's fine
+      }
     } catch (err) {
       statusEl.textContent = `error: ${err}`;
       btnStop.disabled = false;
+    }
+  });
+
+  // ── Suggestion button ──────────────────────────────────────────────
+  btnSuggest.addEventListener("click", async () => {
+    try {
+      btnSuggest.disabled = true;
+      suggestionContent.textContent = "Thinking…";
+      const suggestion = (await invoke("get_suggestion")) as string | null;
+      suggestionContent.textContent = suggestion ?? "No suggestions available.";
+    } catch (err) {
+      suggestionContent.textContent = `Error: ${err}`;
+    } finally {
+      btnSuggest.disabled = false;
     }
   });
 

--- a/crates/murmur-copilot/src/index.html
+++ b/crates/murmur-copilot/src/index.html
@@ -12,6 +12,7 @@
       <button id="btn-start" class="btn btn-start">Start Meeting</button>
       <button id="btn-stop" class="btn btn-stop" disabled>Stop Meeting</button>
       <button id="btn-stealth" class="btn btn-stealth">👁 Stealth: OFF</button>
+      <span id="llm-status" class="llm-status" title="LLM disconnected">🔴</span>
       <span id="status" class="status">idle</span>
     </header>
     <div class="settings">
@@ -21,6 +22,17 @@
       </select>
     </div>
     <main id="transcript" class="transcript"></main>
+    <section id="suggestion-panel" class="suggestion-panel hidden">
+      <div class="suggestion-header">
+        <span>💡 AI Suggestions</span>
+        <button id="btn-suggest" class="btn btn-suggest">Get Suggestion</button>
+      </div>
+      <div id="suggestion-content" class="suggestion-content">No suggestions yet.</div>
+    </section>
+    <section id="summary-panel" class="summary-panel hidden">
+      <div class="summary-header">📋 Meeting Summary</div>
+      <div id="summary-content" class="summary-content"></div>
+    </section>
   </div>
   <script src="main.ts" type="module"></script>
 </body>

--- a/crates/murmur-copilot/src/styles.css
+++ b/crates/murmur-copilot/src/styles.css
@@ -130,3 +130,72 @@ html, body {
   background: rgba(255, 255, 255, 0.15);
   border-radius: 2px;
 }
+
+/* ── LLM Status ──────────────────────────────────────── */
+
+.llm-status {
+  font-size: 10px;
+  cursor: default;
+}
+
+/* ── Suggestion Panel ────────────────────────────────── */
+
+.suggestion-panel {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 8px 0;
+  -webkit-app-region: no-drag;
+}
+
+.suggestion-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 12px;
+  opacity: 0.8;
+  margin-bottom: 6px;
+}
+
+.btn-suggest {
+  background: #f59e0b;
+  color: #0a0a0a;
+  font-size: 11px;
+  padding: 3px 10px;
+}
+
+.suggestion-content {
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  max-height: 120px;
+  overflow-y: auto;
+  opacity: 0.85;
+}
+
+/* ── Summary Panel ───────────────────────────────────── */
+
+.summary-panel {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 8px 0;
+  -webkit-app-region: no-drag;
+}
+
+.summary-header {
+  font-size: 12px;
+  opacity: 0.8;
+  margin-bottom: 6px;
+}
+
+.summary-content {
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  max-height: 200px;
+  overflow-y: auto;
+  opacity: 0.85;
+}
+
+/* ── Utility ─────────────────────────────────────────── */
+
+.hidden {
+  display: none;
+}

--- a/crates/murmur-core/Cargo.toml
+++ b/crates/murmur-core/Cargo.toml
@@ -13,7 +13,7 @@ hound = "3.5"
 arboard = "3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-reqwest = { version = "0.13", features = ["blocking"] }
+reqwest = { version = "0.13", features = ["blocking", "json"] }
 dirs = "6"
 regex = "1"
 anyhow = "1"

--- a/crates/murmur-core/src/config.rs
+++ b/crates/murmur-core/src/config.rs
@@ -223,6 +223,12 @@ pub struct Config {
     /// Hide the overlay window from screen capture and screen sharing.
     #[serde(default)]
     pub stealth_mode: bool,
+    /// LLM model name for Ollama (default: "phi3")
+    #[serde(default = "default_llm_model")]
+    pub llm_model: String,
+    /// Ollama API base URL
+    #[serde(default = "default_ollama_url")]
+    pub ollama_url: String,
 }
 
 fn default_true() -> bool {
@@ -235,6 +241,14 @@ fn default_wake_word() -> String {
 
 fn default_stop_phrase() -> String {
     "murmur stop dictation".to_string()
+}
+
+fn default_llm_model() -> String {
+    "phi3".to_string()
+}
+
+fn default_ollama_url() -> String {
+    "http://localhost:11434".to_string()
 }
 
 impl Default for Config {
@@ -260,6 +274,8 @@ impl Default for Config {
             notes_dir: None,
             system_audio_device: None,
             stealth_mode: false,
+            llm_model: default_llm_model(),
+            ollama_url: default_ollama_url(),
         }
     }
 }

--- a/crates/murmur-core/src/lib.rs
+++ b/crates/murmur-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod audio;
 pub mod config;
 pub mod context;
+pub mod llm;
 pub mod transcription;

--- a/crates/murmur-core/src/llm/mod.rs
+++ b/crates/murmur-core/src/llm/mod.rs
@@ -1,0 +1,31 @@
+pub mod ollama;
+pub mod prompt;
+
+use anyhow::Result;
+
+/// A message in a conversation with the LLM.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ChatMessage {
+    pub role: Role,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Role {
+    System,
+    User,
+    Assistant,
+}
+
+/// Trait for LLM providers (Ollama, llama.cpp, cloud APIs in future).
+pub trait LlmProvider: Send + Sync {
+    /// Generate a completion for the given messages.
+    fn generate(&self, messages: &[ChatMessage]) -> Result<String>;
+
+    /// Check if the provider is available and has a model loaded.
+    fn is_available(&self) -> bool;
+
+    /// Get the name of the current model.
+    fn model_name(&self) -> &str;
+}

--- a/crates/murmur-core/src/llm/ollama.rs
+++ b/crates/murmur-core/src/llm/ollama.rs
@@ -1,0 +1,169 @@
+use anyhow::{Context, Result};
+use log::{info, warn};
+
+use super::{ChatMessage, LlmProvider};
+
+/// Ollama LLM provider — communicates with a local Ollama instance via HTTP.
+/// Ollama must be installed and running (`ollama serve`).
+pub struct OllamaProvider {
+    base_url: String,
+    model: String,
+}
+
+/// Response from the Ollama `/api/tags` endpoint.
+#[derive(serde::Deserialize)]
+struct TagsResponse {
+    models: Vec<TagModel>,
+}
+
+#[derive(serde::Deserialize)]
+struct TagModel {
+    name: String,
+}
+
+/// Request body for `/api/chat`.
+#[derive(serde::Serialize)]
+struct ChatRequest<'a> {
+    model: &'a str,
+    messages: &'a [ChatMessage],
+    stream: bool,
+}
+
+/// Response from `/api/chat` (non-streaming).
+#[derive(serde::Deserialize)]
+struct ChatResponse {
+    message: ChatResponseMessage,
+}
+
+#[derive(serde::Deserialize)]
+struct ChatResponseMessage {
+    content: String,
+}
+
+/// Request body for `/api/pull`.
+#[derive(serde::Serialize)]
+struct PullRequest<'a> {
+    model: &'a str,
+    stream: bool,
+}
+
+impl OllamaProvider {
+    pub fn new(model: &str) -> Self {
+        Self {
+            base_url: "http://localhost:11434".to_string(),
+            model: model.to_string(),
+        }
+    }
+
+    pub fn with_url(base_url: &str, model: &str) -> Self {
+        Self {
+            base_url: base_url.trim_end_matches('/').to_string(),
+            model: model.to_string(),
+        }
+    }
+
+    /// Check if Ollama is running and the configured model is available.
+    pub fn check_health(&self) -> Result<bool> {
+        let url = format!("{}/api/tags", self.base_url);
+        let resp = reqwest::blocking::get(&url).context("failed to reach Ollama")?;
+        let tags: TagsResponse = resp
+            .json()
+            .context("invalid response from Ollama /api/tags")?;
+        let available = tags
+            .models
+            .iter()
+            .any(|m| m.name == self.model || m.name.starts_with(&format!("{}:", self.model)));
+        Ok(available)
+    }
+
+    /// Pull the configured model if it is not already available.
+    pub fn ensure_model(&self) -> Result<()> {
+        if self.check_health().unwrap_or(false) {
+            info!("model '{}' already available", self.model);
+            return Ok(());
+        }
+
+        info!("pulling model '{}'…", self.model);
+        let url = format!("{}/api/pull", self.base_url);
+        let client = reqwest::blocking::Client::new();
+        let resp = client
+            .post(&url)
+            .json(&PullRequest {
+                model: &self.model,
+                stream: false,
+            })
+            .send()
+            .context("failed to pull model from Ollama")?;
+
+        if !resp.status().is_success() {
+            anyhow::bail!(
+                "Ollama pull failed with status {}: {}",
+                resp.status(),
+                resp.text().unwrap_or_default()
+            );
+        }
+
+        info!("model '{}' pulled successfully", self.model);
+        Ok(())
+    }
+}
+
+impl LlmProvider for OllamaProvider {
+    fn generate(&self, messages: &[ChatMessage]) -> Result<String> {
+        let url = format!("{}/api/chat", self.base_url);
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(120))
+            .build()?;
+
+        let resp = client
+            .post(&url)
+            .json(&ChatRequest {
+                model: &self.model,
+                messages,
+                stream: false,
+            })
+            .send()
+            .context("failed to send chat request to Ollama")?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().unwrap_or_default();
+            anyhow::bail!("Ollama chat failed ({status}): {body}");
+        }
+
+        let chat: ChatResponse = resp
+            .json()
+            .context("invalid response from Ollama /api/chat")?;
+        Ok(chat.message.content)
+    }
+
+    fn is_available(&self) -> bool {
+        self.check_health().unwrap_or_else(|e| {
+            warn!("Ollama health check failed: {e}");
+            false
+        })
+    }
+
+    fn model_name(&self) -> &str {
+        &self.model
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_provider_creation() {
+        let p = OllamaProvider::new("phi3");
+        assert_eq!(p.model_name(), "phi3");
+        assert_eq!(p.base_url, "http://localhost:11434");
+    }
+
+    #[test]
+    fn test_provider_with_custom_url() {
+        let p = OllamaProvider::with_url("http://192.168.1.10:11434/", "qwen2.5:1.5b");
+        assert_eq!(p.model_name(), "qwen2.5:1.5b");
+        assert_eq!(p.base_url, "http://192.168.1.10:11434");
+    }
+}

--- a/crates/murmur-core/src/llm/prompt.rs
+++ b/crates/murmur-core/src/llm/prompt.rs
@@ -1,0 +1,97 @@
+use super::{ChatMessage, Role};
+
+/// System prompt for meeting assistance.
+pub fn meeting_system_prompt() -> String {
+    "You are a meeting assistant. You help users during live meetings by providing \
+     concise, relevant suggestions based on the conversation transcript. Be brief \
+     and actionable. Focus on: key discussion points, potential action items, \
+     clarifying questions the user could ask, and relevant context."
+        .to_string()
+}
+
+/// Build a suggestion request from a transcript chunk.
+pub fn suggestion_prompt(transcript: &str) -> Vec<ChatMessage> {
+    vec![
+        ChatMessage {
+            role: Role::System,
+            content: meeting_system_prompt(),
+        },
+        ChatMessage {
+            role: Role::User,
+            content: format!(
+                "Based on the following meeting transcript, provide 2-3 brief, \
+                 actionable suggestions (questions to ask, points to raise, or \
+                 things to clarify):\n\n{transcript}"
+            ),
+        },
+    ]
+}
+
+/// Build a post-meeting summary request.
+pub fn summary_prompt(full_transcript: &str) -> Vec<ChatMessage> {
+    vec![
+        ChatMessage {
+            role: Role::System,
+            content: meeting_system_prompt(),
+        },
+        ChatMessage {
+            role: Role::User,
+            content: format!(
+                "Generate a concise summary of the following meeting transcript. \
+                 Include: key topics discussed, decisions made, and any open \
+                 questions.\n\n{full_transcript}"
+            ),
+        },
+    ]
+}
+
+/// Build an action-items extraction request.
+pub fn action_items_prompt(full_transcript: &str) -> Vec<ChatMessage> {
+    vec![
+        ChatMessage {
+            role: Role::System,
+            content: meeting_system_prompt(),
+        },
+        ChatMessage {
+            role: Role::User,
+            content: format!(
+                "Extract all action items from the following meeting transcript. \
+                 For each action item, identify who is responsible (if mentioned) \
+                 and any deadlines discussed. Format as a numbered list.\n\n\
+                 {full_transcript}"
+            ),
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn suggestion_prompt_includes_transcript() {
+        let msgs = suggestion_prompt("Alice: We should update the API docs.");
+        assert_eq!(msgs.len(), 2);
+        assert!(msgs[1]
+            .content
+            .contains("Alice: We should update the API docs."));
+    }
+
+    #[test]
+    fn summary_prompt_includes_transcript() {
+        let msgs = summary_prompt("Bob: The release is scheduled for Friday.");
+        assert_eq!(msgs.len(), 2);
+        assert!(msgs[1]
+            .content
+            .contains("Bob: The release is scheduled for Friday."));
+    }
+
+    #[test]
+    fn action_items_prompt_includes_transcript() {
+        let msgs = action_items_prompt("Carol: I'll handle the deployment.");
+        assert_eq!(msgs.len(), 2);
+        assert!(msgs[1]
+            .content
+            .contains("Carol: I'll handle the deployment."));
+    }
+}

--- a/crates/murmur/src/app/state.rs
+++ b/crates/murmur/src/app/state.rs
@@ -541,6 +541,8 @@ impl AppState {
             notes_dir: base.notes_dir.clone(),
             system_audio_device: base.system_audio_device.clone(),
             stealth_mode: base.stealth_mode,
+            llm_model: base.llm_model.clone(),
+            ollama_url: base.ollama_url.clone(),
         }
     }
 }


### PR DESCRIPTION
## Phase 3 — Local LLM Integration

### murmur-core (`llm/` module)
- **`LlmProvider` trait** — provider-agnostic interface for LLM backends
- **`OllamaProvider`** — communicates with local Ollama via HTTP API (`/api/chat`, `/api/tags`, `/api/pull`)
- **Prompt templates** — meeting suggestions, summaries, action item extraction
- **Config** — `llm_model` (default: "phi3"), `ollama_url` fields with serde defaults

### murmur-copilot
- **`LlmManager`** — wraps provider with graceful degradation when Ollama is unavailable
- **Async Tauri commands** — `get_suggestion`, `generate_summary`, `extract_action_items` use `spawn_blocking` to avoid freezing UI
- **`get_llm_status`** — reports LLM availability and model name
- **Frontend** — suggestion panel, summary view, LLM status indicator (🟢/🔴)

### Review fixes applied
- Fixed Ollama `/api/pull` field name (`name` → `model`)
- Made LLM commands async with `tokio::task::spawn_blocking` to prevent UI freezes
- Wrapped `LlmManager` in `Arc<Mutex<>>` for safe cross-thread access

### Verification
- ✅ 274 tests pass
- ✅ Clippy clean (full workspace)
- ✅ No regressions