### PR TITLE
fix(test): increase pipeline silence budget to 15ms for CI runners

### DIFF
--- a/crates/murmur/tests/perf_pipeline.rs
+++ b/crates/murmur/tests/perf_pipeline.rs
@@ -271,8 +271,8 @@ fn golden_pipeline_silence_fast_path() {
     let per_call = elapsed / BENCH_ITERS as u32;
 
     assert!(
-        per_call < Duration::from_millis(VAD_SILENCE_BUDGET_MS),
-        "Full silence pipeline took {per_call:?} per call (budget: {VAD_SILENCE_BUDGET_MS}ms)"
+        per_call < Duration::from_millis(15),
+        "Full silence pipeline took {per_call:?} per call (budget: 15ms)"
     );
 }
 


### PR DESCRIPTION
Fixes flaky `golden_pipeline_silence_fast_path` test that does mono mixing + resampling + VAD but was using the 5ms VAD-only budget. Shared CI runners with coverage instrumentation regularly take 6-7ms. Bumped to 15ms — still well within real-time requirements.

Failure: https://github.com/jafreck/murmur/actions/runs/23670809382/job/68963674922